### PR TITLE
Add node-udp-logger image.

### DIFF
--- a/.github/workflows/action-push.yml
+++ b/.github/workflows/action-push.yml
@@ -40,3 +40,13 @@ jobs:
           push: true
           tags: |
             ghcr.io/metalbear-co/mirrord-node:latest            
+      - name: Node UDP Logger - build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: node
+          file: node-udp-logger/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/metalbear-co/mirrord-node-udp-logger:latest
+

--- a/node-udp-logger/Dockerfile
+++ b/node-udp-logger/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:buster
+WORKDIR /app
+COPY app.mjs .
+ENTRYPOINT ["node", "app.mjs"]
+

--- a/node-udp-logger/app.mjs
+++ b/node-udp-logger/app.mjs
@@ -1,0 +1,18 @@
+import dgram from 'node:dgram';
+
+const server = dgram.createSocket('udp4');
+
+server.on('error', (err) => {
+  console.log(`server error:\n${err.stack}`);
+  server.close();
+  throw err
+});
+
+server.on('message', (msg, rinfo) => {
+  console.log(`${rinfo.address}:${rinfo.port}: ${msg}`);
+});
+
+server.on('listening', () => {
+});
+
+server.bind(31415);


### PR DESCRIPTION
This image will be used to test outging udp traffic in mirrord. The udp-logger will be deployed such that it is only reachable from the target pod, and the `mirrord`ed process will send a message to the logger over UDP. The logger logs the message and the tests read the logs to verify that the message arrived.