### PR TITLE
add missing platform.sh to http-keep-alive

### DIFF
--- a/http-keep-alive/platform.sh
+++ b/http-keep-alive/platform.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Used in Docker build to set platform dependent variables
+
+case $TARGETARCH in
+
+    "amd64")
+	echo "x86_64-unknown-linux-gnu" > /.platform
+	echo "" > /.compiler 
+	;;
+    "arm64") 
+	echo "aarch64-unknown-linux-gnu" > /.platform
+	echo "gcc-aarch64-linux-gnu" > /.compiler
+	;;
+    "arm")
+	echo "armv7-unknown-linux-gnueabihf" > /.platform
+	echo "gcc-arm-linux-gnueabihf" > /.compiler
+	;;
+esac
+


### PR DESCRIPTION
http-keep-alive [failes to build](https://github.com/metalbear-co/test-images/actions/runs/6113563406/job/16593991476) because this file is used in its Dockerfile but is not present where it's expected.