### PR TITLE
Move broken unix sockets image to the end of the CI

### DIFF
--- a/.github/workflows/action-push.yml
+++ b/.github/workflows/action-push.yml
@@ -85,15 +85,6 @@ jobs:
           push: true
           tags: |
             ghcr.io/metalbear-co/mirrord-websocket:latest
-      - name: unix-socket-server - build and push
-        uses: docker/build-push-action@v3
-        with:
-          context: unix-socket-server
-          file: unix-socket-server/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/metalbear-co/mirrord-unix-socket-server:latest
       - name: http-keep-alive - build and push
         uses: docker/build-push-action@v3
         with:
@@ -112,4 +103,13 @@ jobs:
           push: true
           tags: |
             ghcr.io/metalbear-co/mirrord-sqs-forwarder:latest
+      - name: unix-socket-server - build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: unix-socket-server
+          file: unix-socket-server/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/metalbear-co/mirrord-unix-socket-server:latest
 

--- a/.github/workflows/action-push.yml
+++ b/.github/workflows/action-push.yml
@@ -103,6 +103,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/metalbear-co/mirrord-sqs-forwarder:latest
+      # TODO: this is broken.
       - name: unix-socket-server - build and push
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
[The unix sockets image is broken](https://github.com/metalbear-co/test-images/issues/22), and since SQS is built and published in a later step than the unix sockets, it was not published.

This PR moves the broken step to be last as a temporary workaround. The broken image is not currently a problem for itself because it wasn't changed and there is already a published image.