### PR TITLE
Change python test app to take the host and port to listen on from the env

### DIFF
--- a/python/app.py
+++ b/python/app.py
@@ -1,6 +1,18 @@
 from flask import Flask
 
-PORT = 80
+import os
+
+try:
+    HOST = os.environ['HOST']
+except KeyError:
+    HOST = "0.0.0.0"
+
+try:
+    PORT = os.environ['PORT']
+except KeyError:
+    PORT = 80
+
+print(f"Will listen on {HOST}:{PORT}")
 
 app = Flask(__name__)
 
@@ -26,4 +38,4 @@ def delete():
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=PORT)
+    app.run(host=HOST, port=PORT)


### PR DESCRIPTION
For https://github.com/metalbear-co/mirrord/pull/2976, so that we can use that image also for a workload that listens on IPv6. 