### PR TITLE
don't use root path in statfs test image

### DIFF
--- a/go-statfs/main.go
+++ b/go-statfs/main.go
@@ -10,9 +10,9 @@ import (
 )
 
 func main() {
-	rootPath := "/"
+	testPath := "/app/test.txt"
 	var statfs syscall.Statfs_t
-	err := syscall.Statfs(rootPath, &statfs)
+	err := syscall.Statfs(testPath, &statfs)
 	if err != nil {
 		fmt.Println("Error:", err)
 		return


### PR DESCRIPTION
It's probably not a problem right now, but the local test app changed in https://github.com/metalbear-co/mirrord/pull/3085 not to use the root path, because that path should actually be bypassed, so let's change the path here as well, so that they match.